### PR TITLE
PI-8328: getProducts request is now sent with rounded display amounts

### DIFF
--- a/filter/actions/applyFilters.js
+++ b/filter/actions/applyFilters.js
@@ -12,8 +12,8 @@ import { FILTER_PATH } from '../constants';
 
 /**
  * Applies the filters to the products and navigates back to the previous route containing products.
- * @param {boolean} roundDisplayAmounts If set to TRUE the values of the display_amount will be
- *   rounded to the next full number.
+ * @param {boolean} [roundDisplayAmounts=true] If set to TRUE the values of the display_amount will
+ *   be rounded to the next full number.
  * @returns {Function} A redux thunk
  */
 const applyFilters = (roundDisplayAmounts = true) => (dispatch, getState) => {

--- a/filter/actions/applyFilters.js
+++ b/filter/actions/applyFilters.js
@@ -12,10 +12,12 @@ import { FILTER_PATH } from '../constants';
 
 /**
  * Applies the filters to the products and navigates back to the previous route containing products.
+ * @param {boolean} roundDisplayAmounts If set to TRUE the values of the display_amount will be
+ *   rounded to the next full number.
  * @returns {Function} A redux thunk
  */
-const applyFilters = () => (dispatch, getState) => {
-  dispatch(commitTemporaryFilters());
+const applyFilters = (roundDisplayAmounts = true) => (dispatch, getState) => {
+  dispatch(commitTemporaryFilters(roundDisplayAmounts));
 
   const path = getHistoryPathname(getState());
 

--- a/filter/actions/commitTemporaryFilters.js
+++ b/filter/actions/commitTemporaryFilters.js
@@ -10,18 +10,30 @@ import { logger } from '@shopgate/pwa-core/helpers';
 import { ITEMS_PER_LOAD } from '@shopgate/pwa-common/constants/DisplayOptions';
 import { getSortOrder } from '@shopgate/pwa-common/selectors/history';
 import setActiveFilters from '../action-creators/setActiveFilters';
-import { getActiveFiltersStack, getTemporaryFilters } from '../selectors';
+import {
+  getActiveFiltersStack,
+  getTemporaryFilters,
+  getTemporaryFiltersWithRoudedDisplayAmounts,
+} from '../selectors';
 import getProducts from '../../product/actions/getProducts';
 import buildFilterParams from './helpers/buildFilterParams';
 
 /**
  * Submits the temporary state to the active filters.
+ * @param {boolean} roundDisplayAmounts If set to TRUE the values of the display_amount will be
+ *   rounded to the next full number.
  * @returns {Function} A redux thunk.
  */
-const commitTemporaryFilters = () => (dispatch, getState) => {
+const commitTemporaryFilters = (roundDisplayAmounts = true) => (dispatch, getState) => {
   const state = getState();
   const activeFilters = getActiveFiltersStack(state);
-  const temporaryFilters = getTemporaryFilters(state);
+  let temporaryFilters;
+
+  if (roundDisplayAmounts) {
+    temporaryFilters = getTemporaryFiltersWithRoudedDisplayAmounts(state);
+  } else {
+    temporaryFilters = getTemporaryFilters(state);
+  }
 
   if (!activeFilters.length) {
     logger.error('Tried to submit temporary filters, but no active filter stack was created.');

--- a/filter/actions/commitTemporaryFilters.js
+++ b/filter/actions/commitTemporaryFilters.js
@@ -20,8 +20,8 @@ import buildFilterParams from './helpers/buildFilterParams';
 
 /**
  * Submits the temporary state to the active filters.
- * @param {boolean} roundDisplayAmounts If set to TRUE the values of the display_amount will be
- *   rounded to the next full number.
+ * @param {boolean} [roundDisplayAmounts=true] If set to TRUE the values of the display_amount will
+ *   be rounded to the next full number.
  * @returns {Function} A redux thunk.
  */
 const commitTemporaryFilters = (roundDisplayAmounts = true) => (dispatch, getState) => {

--- a/filter/selectors/index.js
+++ b/filter/selectors/index.js
@@ -144,6 +144,38 @@ export const getTemporaryFilters = state => (
 );
 
 /**
+ * Gets the temporary stored filter settings and rounds the display amounts. The minimum amount
+ * is rounded down, and the maximum amount is rounded down to the next full number.
+ * @return {Object}
+ */
+export const getTemporaryFiltersWithRoudedDisplayAmounts = createSelector(
+  getTemporaryFilters,
+  (filters) => {
+    // Create a clone of the filters to avoid reference issues.
+    const result = {
+      ...filters,
+    };
+
+    let { display_amount: displayAmount } = result;
+
+    if (displayAmount) {
+      const { minimum, maximum } = displayAmount;
+      // Round the minimum an and the maximum display amounts.
+      displayAmount = {
+        ...displayAmount,
+        minimum: Math.floor(minimum / 100) * 100,
+        maximum: Math.ceil(maximum / 100) * 100,
+      };
+    }
+
+    return {
+      ...result,
+      display_amount: displayAmount,
+    };
+  }
+);
+
+/**
  * Finds a single filter in a list of filters by id.
  * @param {Array} filters A list of filters.
  * @param {string} id The filter id

--- a/filter/selectors/index.js
+++ b/filter/selectors/index.js
@@ -145,7 +145,7 @@ export const getTemporaryFilters = state => (
 
 /**
  * Gets the temporary stored filter settings and rounds the display amounts. The minimum amount
- * is rounded down, and the maximum amount is rounded down to the next full number.
+ * is rounded down, and the maximum amount is rounded up to the next full number.
  * @return {Object}
  */
 export const getTemporaryFiltersWithRoudedDisplayAmounts = createSelector(


### PR DESCRIPTION
- the minimum is now rounded down to the next full amount without fractions
- the maximum is now rounded up to the next full amount without fractions
- this causes that the request is now sent with a minimum display amount is now sent with 1900 if the actual filter is set to 1950
- the commitTemporaryFilters() action got an option to reactivate the old behavior