### PR TITLE
CON-2460: Blocked getCart request in cart till other requests finished

### DIFF
--- a/cart/action-creators/errorAddCouponsToCart.js
+++ b/cart/action-creators/errorAddCouponsToCart.js
@@ -11,12 +11,14 @@ import { ERROR_ADD_COUPONS_TO_CART } from '../constants';
  * Creates the dispatched ERROR_ADD_COUPONS_TO_CART action object.
  * @param {Array} couponsIds The coupon ids from the failed ADD_COUPONS_TO_CART action.
  * @param {Array} [errors] A list of errors messages for the coupons.
+ * @param {boolean} [requestsPending=false] Tells if other cart related requests are pending.
  * @returns {Object} The dispatched action object.
  */
-const errorAddCouponsToCart = (couponsIds, errors = []) => ({
+const errorAddCouponsToCart = (couponsIds, errors = [], requestsPending = false) => ({
   type: ERROR_ADD_COUPONS_TO_CART,
   couponsIds,
   errors,
+  requestsPending,
 });
 
 export default errorAddCouponsToCart;

--- a/cart/action-creators/errorAddProductsToCart.js
+++ b/cart/action-creators/errorAddProductsToCart.js
@@ -12,12 +12,14 @@ import { ERROR_ADD_PRODUCTS_TO_CART } from '../constants';
  * @param {Array} products The products that where supposed to be added within
  *   an ADD_PRODUCTS_TO_CART action.
  * @param {Array} [errors] A list of errors messages for the products.
+ * @param {boolean} [requestsPending=false] Tells if other cart related requests are pending.
  * @returns {Object} The dispatched action object.
  */
-const errorAddProductsToCart = (products, errors = []) => ({
+const errorAddProductsToCart = (products, errors = [], requestsPending = false) => ({
   type: ERROR_ADD_PRODUCTS_TO_CART,
   products,
   errors,
+  requestsPending,
 });
 
 export default errorAddProductsToCart;

--- a/cart/action-creators/errorDeleteCouponsFromCart.js
+++ b/cart/action-creators/errorDeleteCouponsFromCart.js
@@ -11,12 +11,14 @@ import { ERROR_DELETE_COUPONS_FROM_CART } from '../constants';
  * Creates the dispatched ERROR_DELETE_COUPONS_FROM_CART action object.
  * @param {Array} couponsIds The coupon ids from the failed DELETE_COUPONS_FROM_CART action.
  * @param {Array} [errors] A list of errors messages for the coupons.
+ * @param {boolean} [requestsPending=false] Tells if other cart related requests are pending.
  * @returns {Object} The dispatched action object.
  */
-const errorDeleteCouponsFromCart = (couponsIds, errors = []) => ({
+const errorDeleteCouponsFromCart = (couponsIds, errors = [], requestsPending = false) => ({
   type: ERROR_DELETE_COUPONS_FROM_CART,
   couponsIds,
   errors,
+  requestsPending,
 });
 
 export default errorDeleteCouponsFromCart;

--- a/cart/action-creators/errorDeleteProductsFromCart.js
+++ b/cart/action-creators/errorDeleteProductsFromCart.js
@@ -12,12 +12,14 @@ import { ERROR_DELETE_PRODUCTS_FROM_CART } from '../constants';
  * @param {Array} products The products that where supposed to be deleted within
  *   an DELETE_PRODUCTS_FROM_CART action.
  * @param {Array} [errors] A list of errors messages for the products.
+ * @param {boolean} [requestsPending=false] Tells if other cart related requests are pending.
  * @returns {Object} The dispatched action object.
  */
-const errorDeleteProductsFromCart = (products, errors = []) => ({
+const errorDeleteProductsFromCart = (products, errors = [], requestsPending = false) => ({
   type: ERROR_DELETE_PRODUCTS_FROM_CART,
   products,
   errors,
+  requestsPending,
 });
 
 export default errorDeleteProductsFromCart;

--- a/cart/action-creators/errorUpdateProductsInCart.js
+++ b/cart/action-creators/errorUpdateProductsInCart.js
@@ -11,12 +11,14 @@ import { ERROR_UPDATE_PRODUCTS_IN_CART } from '../constants';
  * Creates the dispatched ERROR_UPDATE_PRODUCTS_IN_CART action object.
  * @param {Array} updateData The update data from the failed UPDATE_PRODUCTS_IN_CART action.
  * @param {Array} [errors] A list of errors messages for the products.
+ * @param {boolean} [requestsPending=false] Tells if other cart related requests are pending.
  * @returns {Object} The dispatched action object.
  */
-const errorUpdateProductsInCart = (updateData, errors = []) => ({
+const errorUpdateProductsInCart = (updateData, errors = [], requestsPending = true) => ({
   type: ERROR_UPDATE_PRODUCTS_IN_CART,
   updateData,
   errors,
+  requestsPending,
 });
 
 export default errorUpdateProductsInCart;

--- a/cart/action-creators/successAddCouponsToCart.js
+++ b/cart/action-creators/successAddCouponsToCart.js
@@ -10,11 +10,13 @@ import { SUCCESS_ADD_COUPONS_TO_CART } from '../constants';
 /**
  * Creates the dispatched SUCCESS_ADD_COUPONS_TO_CART action object.
  * @param {Array} couponsIds The coupon ids from the successful ADD_COUPONS_TO_CART action.
+ * @param {boolean} [requestsPending=false] Tells if other cart related requests are pending.
  * @returns {Object} The dispatched action object.
  */
-const successAddCouponsToCart = couponsIds => ({
+const successAddCouponsToCart = (couponsIds, requestsPending = false) => ({
   type: SUCCESS_ADD_COUPONS_TO_CART,
   couponsIds,
+  requestsPending,
 });
 
 export default successAddCouponsToCart;

--- a/cart/action-creators/successAddProductsToCart.js
+++ b/cart/action-creators/successAddProductsToCart.js
@@ -9,10 +9,12 @@ import { SUCCESS_ADD_PRODUCTS_TO_CART } from '../constants';
 
 /**
  * Creates the dispatched SUCCESS_ADD_PRODUCTS_TO_CART action object.
+ * @param {boolean} [requestsPending=false] Tells if other cart related requests are pending.
  * @returns {Object} The dispatched action object.
  */
-const successAddProductsToCart = () => ({
+const successAddProductsToCart = (requestsPending = false) => ({
   type: SUCCESS_ADD_PRODUCTS_TO_CART,
+  requestsPending,
 });
 
 export default successAddProductsToCart;

--- a/cart/action-creators/successDeleteCouponsFromCart.js
+++ b/cart/action-creators/successDeleteCouponsFromCart.js
@@ -9,10 +9,12 @@ import { SUCCESS_DELETE_COUPONS_FROM_CART } from '../constants';
 
 /**
  * Creates the dispatched SUCCESS_DELETE_COUPONS_FROM_CART action object.
+ * @param {boolean} [requestsPending=false] Tells if other cart related requests are pending.
  * @returns {Object} The dispatched action object.
  */
-const successDeleteCouponsFromCart = () => ({
+const successDeleteCouponsFromCart = (requestsPending = false) => ({
   type: SUCCESS_DELETE_COUPONS_FROM_CART,
+  requestsPending,
 });
 
 export default successDeleteCouponsFromCart;

--- a/cart/action-creators/successDeleteProductsFromCart.js
+++ b/cart/action-creators/successDeleteProductsFromCart.js
@@ -9,10 +9,12 @@ import { SUCCESS_ADD_PRODUCTS_TO_CART } from '../constants';
 
 /**
  * Creates the dispatched SUCCESS_DELETE_PRODUCTS_FROM_CART action object.
+ * @param {boolean} [requestsPending=false] Tells if other cart related requests are pending.
  * @returns {Object} The dispatched action object.
  */
-const successDeleteProductsFromCart = () => ({
+const successDeleteProductsFromCart = (requestsPending = false) => ({
   type: SUCCESS_ADD_PRODUCTS_TO_CART,
+  requestsPending,
 });
 
 export default successDeleteProductsFromCart;

--- a/cart/action-creators/successUpdateProductsInCart.js
+++ b/cart/action-creators/successUpdateProductsInCart.js
@@ -9,10 +9,12 @@ import { SUCCESS_UPDATE_PRODUCTS_IN_CART } from '../constants';
 
 /**
  * Creates the dispatched SUCCESS_UPDATE_PRODUCTS_IN_CART action object.
+ * @param {boolean} [requestsPending=false] Tells if other cart related requests are pending.
  * @returns {Object} The dispatched action object.
  */
-const successUpdateProductsInCart = () => ({
+const successUpdateProductsInCart = (requestsPending = false) => ({
   type: SUCCESS_UPDATE_PRODUCTS_IN_CART,
+  requestsPending,
 });
 
 export default successUpdateProductsInCart;

--- a/cart/actions/addCouponsToCart.js
+++ b/cart/actions/addCouponsToCart.js
@@ -19,20 +19,22 @@ import successAddCouponsToCart from '../action-creators/successAddCouponsToCart'
 const addCouponsToCart = couponIds => dispatch => new Promise((resolve, reject) => {
   dispatch(addCoupons(couponIds));
 
-  new PipelineRequest('addCouponsToCart')
-    .setInput({ couponCodes: couponIds })
+  const request = new PipelineRequest('addCouponsToCart');
+  request.setInput({ couponCodes: couponIds })
     .dispatch()
     .then(({ messages }) => {
+      const requestsPending = request.hasPendingRequests();
       if (messages) {
-        dispatch(errorAddCouponsToCart(couponIds, messages));
+        dispatch(errorAddCouponsToCart(couponIds, messages, requestsPending));
         reject();
       } else {
-        dispatch(successAddCouponsToCart(couponIds));
+        dispatch(successAddCouponsToCart(couponIds, requestsPending));
         resolve();
       }
     })
     .catch((error) => {
-      dispatch(errorAddCouponsToCart(couponIds));
+      const requestsPending = request.hasPendingRequests();
+      dispatch(errorAddCouponsToCart(couponIds, undefined, requestsPending));
       logger.error('addCouponsToCart', error);
       reject();
     });

--- a/cart/actions/addProductsToCart.js
+++ b/cart/actions/addProductsToCart.js
@@ -24,11 +24,12 @@ const addToCart = productData => (dispatch, getState) => {
   dispatch(addProductsToCart(productData));
   dispatch(setCartProductPendingCount(pendingProductCount + 1));
 
-  new PipelineRequest('addProductsToCart')
-    .setInput({ products: productData })
+  const request = new PipelineRequest('addProductsToCart');
+  request.setInput({ products: productData })
     .dispatch()
     .then(({ messages }) => {
-      dispatch(successAddProductsToCart());
+      const requestsPending = request.hasPendingRequests();
+      dispatch(successAddProductsToCart(requestsPending));
 
       if (messages) {
         /**
@@ -36,11 +37,12 @@ const addToCart = productData => (dispatch, getState) => {
          * but a messages array within the response payload. So by now we also have to dispatch
          * the error action here.
          */
-        dispatch(errorAddProductsToCart(productData, messages));
+        dispatch(errorAddProductsToCart(productData, messages, requestsPending));
       }
     })
     .catch((error) => {
-      dispatch(errorAddProductsToCart(productData));
+      const requestsPending = request.hasPendingRequests();
+      dispatch(errorAddProductsToCart(productData, undefined, requestsPending));
       logger.error('addProductsToCart', error);
     });
 };

--- a/cart/actions/deleteCouponsFromCart.js
+++ b/cart/actions/deleteCouponsFromCart.js
@@ -19,18 +19,20 @@ import successDeleteCouponsFromCart from '../action-creators/successDeleteCoupon
 const deleteCouponsFromCart = couponIds => (dispatch) => {
   dispatch(deleteCoupons(couponIds));
 
-  new PipelineRequest('deleteCouponsFromCart')
-    .setInput({ couponCodes: couponIds })
+  const request = new PipelineRequest('deleteCouponsFromCart');
+  request.setInput({ couponCodes: couponIds })
     .dispatch()
     .then(({ messages }) => {
-      dispatch(successDeleteCouponsFromCart());
+      const requestsPending = request.hasPendingRequests();
+      dispatch(successDeleteCouponsFromCart(requestsPending));
 
       if (messages) {
-        dispatch(errorDeleteCouponsFromCart(couponIds, messages));
+        dispatch(errorDeleteCouponsFromCart(couponIds, messages, requestsPending));
       }
     })
     .catch((error) => {
-      dispatch(errorDeleteCouponsFromCart(couponIds));
+      const requestsPending = request.hasPendingRequests();
+      dispatch(errorDeleteCouponsFromCart(couponIds, undefined, requestsPending));
       logger.error('deleteCouponsFromCart', error);
     });
 };

--- a/cart/actions/deleteProductsFromCart.js
+++ b/cart/actions/deleteProductsFromCart.js
@@ -19,18 +19,20 @@ import errorDeleteProductsFromCart from '../action-creators/errorDeleteProductsF
 const deleteProductsFromCart = cartItemIds => (dispatch) => {
   dispatch(deleteProducts(cartItemIds));
 
-  new PipelineRequest('deleteProductsFromCart')
-    .setInput({ CartItemIds: cartItemIds })
+  const request = new PipelineRequest('deleteProductsFromCart');
+  request.setInput({ CartItemIds: cartItemIds })
     .dispatch()
     .then(({ messages }) => {
-      dispatch(successDeleteProductsFromCart());
+      const requestsPending = request.hasPendingRequests();
+      dispatch(successDeleteProductsFromCart(requestsPending));
 
       if (messages) {
-        dispatch(errorDeleteProductsFromCart(cartItemIds, messages));
+        dispatch(errorDeleteProductsFromCart(cartItemIds, messages, requestsPending));
       }
     })
     .catch((error) => {
-      dispatch(errorDeleteProductsFromCart(cartItemIds));
+      const requestsPending = request.hasPendingRequests();
+      dispatch(errorDeleteProductsFromCart(cartItemIds, undefined, requestsPending));
       logger.error('deleteProductsFromCart', error);
     });
 };

--- a/cart/actions/updateProductsInCart.js
+++ b/cart/actions/updateProductsInCart.js
@@ -32,18 +32,20 @@ const updateProductsInCart = updateData => (dispatch) => {
 
   dispatch(updateProducts(convertedData));
 
-  new PipelineRequest('updateProductsInCart')
-    .setInput({ CartItem: convertedData })
+  const request = new PipelineRequest('updateProductsInCart');
+  request.setInput({ CartItem: convertedData })
     .dispatch()
     .then(({ messages }) => {
-      dispatch(successUpdateProductsInCart());
+      const requestsPending = request.hasPendingRequests();
+      dispatch(successUpdateProductsInCart(requestsPending));
 
       if (messages) {
-        dispatch(errorUpdateProductsInCart(updateData, messages));
+        dispatch(errorUpdateProductsInCart(updateData, messages, requestsPending));
       }
     })
     .catch((error) => {
-      dispatch(errorUpdateProductsInCart(updateData));
+      const requestsPending = request.hasPendingRequests();
+      dispatch(errorUpdateProductsInCart(updateData, undefined, requestsPending));
       logger.error('updateProductsInCart', error);
     });
 };

--- a/cart/subscriptions/index.js
+++ b/cart/subscriptions/index.js
@@ -81,8 +81,11 @@ export default function cart(subscribe) {
     dispatch(setCartProductPendingCount(0));
   });
 
-  subscribe(cartNeedsSync$, ({ dispatch }) => {
-    dispatch(fetchCart());
+  subscribe(cartNeedsSync$, ({ dispatch, action }) => {
+    const { requestsPending = false } = action;
+    if (requestsPending !== true) {
+      dispatch(fetchCart());
+    }
   });
 
   subscribe(cartBusy$, ({ dispatch }) => {


### PR DESCRIPTION
- this will fix an issue where the cart was visually reset to outdated states while the user heavily interacted with the cart page
- now the getCart pipeline is only called once after the last cart modifying request is finished